### PR TITLE
UARTE power optimization and improvements

### DIFF
--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -131,6 +131,8 @@ where
     }
 
     pub fn free(self) -> (T, T::Interrupt, Pins) {
+        // Wait for the peripheral to be disabled from the ISR.
+        while self.instance.enable.read().enable().is_enabled() {}
         (self.instance, self.irq, self.pins)
     }
 

--- a/embassy-nrf/src/util/mod.rs
+++ b/embassy-nrf/src/util/mod.rs
@@ -1,2 +1,12 @@
 pub mod peripheral;
 pub mod ring_buffer;
+
+/// Low power blocking wait loop using WFE/SEV.
+pub fn low_power_wait_until(mut condition: impl FnMut() -> bool) {
+    while !condition() {
+        // WFE might "eat" an event that would have otherwise woken the executor.
+        cortex_m::asm::wfe();
+    }
+    // Retrigger an event to be transparent to the executor.
+    cortex_m::asm::sev();
+}

--- a/embassy/src/util/signal.rs
+++ b/embassy/src/util/signal.rs
@@ -63,12 +63,7 @@ impl<T: Send> Signal<T> {
         futures::future::poll_fn(move |cx| self.poll_wait(cx))
     }
 
-    /// Blocks until the signal has been received.
-    ///
-    /// Returns immediately when [`poll_wait()`] has not been called before.
-    pub fn blocking_wait(&self) {
-        while cortex_m::interrupt::free(|_| {
-            matches!(unsafe { &*self.state.get() }, State::Waiting(_))
-        }) {}
+    pub fn signaled(&self) -> bool {
+        cortex_m::interrupt::free(|_| matches!(unsafe { &*self.state.get() }, State::Signaled(_)))
     }
 }


### PR DESCRIPTION
I did more testing and current consumption measurements on the UARTE peripheral.
Details of each improvement is described in the commit messages.

There have been three major current consumption improvements:
* Do not spin when stopping a receive future (1st 6mA peak is gone)
* Low power wait when dropping RX futures (2nd 6mA peak is gone)
* Do not try to disable receiver or transmitter when it is disabled already ("tail" of the first falling edge)

before
![before](https://user-images.githubusercontent.com/1181037/103480055-4b7ebc80-4dd2-11eb-998e-7dc1c34514e6.png)

after
![final](https://user-images.githubusercontent.com/1181037/103483332-d5388500-4de6-11eb-8de3-00ed684e7b23.png)

Code for the power consumption test sequence:
``` rust
#[task]
async fn run(mut led: Pin<Output<PushPull>>, mut uart: uarte::Uarte<pac::UARTE0>) {
    let mut buf = [0; 8];

    Timer::after(Duration::from_millis(500)).await;

    buf.copy_from_slice(b"bootboot");
    uart.send(&buf).await.unwrap();

    loop {
        // Wait for data.
        // Receive ends when the DMA buffer is full.
        // Lowest power consumption when ending the transfer because no explicit
        // stop and wait for transfter end required.
        uart.receive(&mut buf).await.unwrap();

        Timer::after(Duration::from_millis(50)).await;

        // Stop transfer with `stop()`: low power consumption while stopping
        if let Either::Right((_, read)) = select(
            uart.receive(&mut buf),
            Timer::after(Duration::from_millis(10)),
        )
        .await
        {
            read.stop().await;
        }

        Timer::after(Duration::from_millis(50)).await;

        // Stop transfer with drop: low power consumption while stopping
        select(
            uart.receive(&mut buf),
            Timer::after(Duration::from_millis(10)),
        )
        .await;

        Timer::after(Duration::from_millis(50)).await;

        // Message must be in SRAM
        buf.copy_from_slice(b"12345678");
        uart.send(&buf).await.unwrap();

        Timer::after(Duration::from_millis(1000)).await;
        led.set_low().unwrap();
        Timer::after(Duration::from_millis(100)).await;
        led.set_high().unwrap();
        Timer::after(Duration::from_millis(100)).await;
    }
}
```