### PR TITLE
RFC: GPIO WaitForFoo traits

### DIFF
--- a/embassy/src/gpio.rs
+++ b/embassy/src/gpio.rs
@@ -1,0 +1,48 @@
+use core::future::Future;
+use core::pin::Pin;
+
+/// Wait for a pin to become high.
+pub trait WaitForHigh {
+    type Future<'a>: Future<Output = ()> + 'a;
+
+    /// Wait for a pin to become high.
+    ///
+    /// If the pin is already high, the future completes immediately.
+    /// Otherwise, it completes when it becomes high.
+    fn wait_for_high<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+}
+
+/// Wait for a pin to become low.
+pub trait WaitForLow {
+    type Future<'a>: Future<Output = ()> + 'a;
+
+    /// Wait for a pin to become low.
+    ///
+    /// If the pin is already low, the future completes immediately.
+    /// Otherwise, it completes when it becomes low.
+    fn wait_for_low<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+}
+
+/// Wait for a rising edge (transition from low to high)
+pub trait WaitForRisingEdge {
+    type Future<'a>: Future<Output = ()> + 'a;
+
+    /// Wait for a rising edge (transition from low to high)
+    fn wait_for_rising_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+}
+
+/// Wait for a falling edge (transition from high to low)
+pub trait WaitForFallingEdge {
+    type Future<'a>: Future<Output = ()> + 'a;
+
+    /// Wait for a falling edge (transition from high to low)
+    fn wait_for_falling_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+}
+
+/// Wait for any edge (any transition, high to low or low to high)
+pub trait WaitForAnyEdge {
+    type Future<'a>: Future<Output = ()> + 'a;
+
+    /// Wait for any edge (any transition, high to low or low to high)
+    fn wait_for_any_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a>;
+}

--- a/embassy/src/lib.rs
+++ b/embassy/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod fmt;
 
 pub mod executor;
 pub mod flash;
+pub mod gpio;
 pub mod interrupt;
 pub mod io;
 pub mod rand;


### PR DESCRIPTION
A very common usage for "pin interrupts" is IRQ lines of external chips. With the current GPIOTE this is not very well abstracted, since a driver would need to take ownership of the GPIOTE peripheral *plus* the irq pin.

The solution is for GPIOTE (and EXTI for stm32, etc) to have an API that creates "pin wrappers" for single pins that implement the proposed traits. This way users can wrap mutiple pins and then hand them out to different driver crates.

A driver crate could use an interrupt pin like this:

```rust
loop { 
   pin.wait_for_low();
   // retrieve whatever events the chip has for us via i2c/spi/etc
}
```

These are separate traits because different hardware supports different features. For example, nrf's GPIOTE PORT event can't wait for edges, only for high/low, while GPIOTE channels can wait for edges. (you might want to use GPIOTE PORT because uses much less power than channels, so we want to support both).

Feedback very welcome! :) 