### PR TITLE
wip: cleanup and parameterize usart

### DIFF
--- a/embassy-stm32f4-examples/src/bin/serial.rs
+++ b/embassy-stm32f4-examples/src/bin/serial.rs
@@ -14,6 +14,7 @@ use embassy::uart::Uart;
 use embassy::util::Forever;
 use embassy_stm32f4::interrupt;
 use embassy_stm32f4::serial;
+use stm32f4xx_hal::serial::config::Config;
 use stm32f4xx_hal::stm32;
 use stm32f4xx_hal::{prelude::*, serial::config};
 
@@ -31,17 +32,17 @@ async fn run(dp: stm32::Peripherals, cp: cortex_m::Peripherals) {
         .freeze();
 
     let mut serial = unsafe {
-        serial::Serial::new(
-            gpioa.pa9.into_alternate_af7(),
-            gpioa.pa10.into_alternate_af7(),
+        serial::Serial::usart1(
+            dp.USART1,
+            dp.DMA2,
+            (
+                gpioa.pa9.into_alternate_af7(),
+                gpioa.pa10.into_alternate_af7(),
+            ),
             interrupt::take!(DMA2_STREAM7),
             interrupt::take!(DMA2_STREAM2),
             interrupt::take!(USART1),
-            dp.DMA2,
-            dp.USART1,
-            config::Parity::ParityNone,
-            config::StopBits::STOP1,
-            9600.bps(),
+            Config::default().baudrate(9600.bps()),
             clocks,
         )
     };

--- a/embassy-stm32f4-examples/src/serial.rs
+++ b/embassy-stm32f4-examples/src/serial.rs
@@ -38,6 +38,7 @@ async fn run(dp: stm32::Peripherals, cp: cortex_m::Peripherals) {
             dp.DMA2,
             dp.USART1,
             config::Parity::ParityNone,
+            config::StopBits::STOP1,
             9600.bps(),
             clocks,
         )

--- a/embassy-stm32f4/Cargo.toml
+++ b/embassy-stm32f4/Cargo.toml
@@ -40,5 +40,5 @@ cortex-m-rt = "0.6.13"
 cortex-m        = { version = "0.6.4" }
 embedded-hal    = { version = "0.2.4" }
 embedded-dma    = { version = "0.1.2" }
-stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], path = "../../stm32f4xx-hal" }
+stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], git = "https://github.com/stm32-rs/stm32f4xx-hal.git"}
 concat-idents  =  "1.1.2"

--- a/embassy-stm32f4/Cargo.toml
+++ b/embassy-stm32f4/Cargo.toml
@@ -40,4 +40,4 @@ cortex-m-rt = "0.6.13"
 cortex-m        = { version = "0.6.4" }
 embedded-hal    = { version = "0.2.4" }
 embedded-dma    = { version = "0.1.2" }
-stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], git = "https://github.com/stm32-rs/stm32f4xx-hal.git"}
+stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], path = "../../stm32f4xx-hal" }

--- a/embassy-stm32f4/Cargo.toml
+++ b/embassy-stm32f4/Cargo.toml
@@ -41,3 +41,4 @@ cortex-m        = { version = "0.6.4" }
 embedded-hal    = { version = "0.2.4" }
 embedded-dma    = { version = "0.1.2" }
 stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], path = "../../stm32f4xx-hal" }
+concat-idents  =  "1.1.2"

--- a/embassy-stm32f4/Cargo.toml
+++ b/embassy-stm32f4/Cargo.toml
@@ -41,4 +41,4 @@ cortex-m        = { version = "0.6.4" }
 embedded-hal    = { version = "0.2.4" }
 embedded-dma    = { version = "0.1.2" }
 stm32f4xx-hal  = { version = "0.8.3", features = ["rt"], git = "https://github.com/stm32-rs/stm32f4xx-hal.git"}
-concat-idents  =  "1.1.2"
+paste = "1.0.4"

--- a/embassy-stm32f4/src/serial.rs
+++ b/embassy-stm32f4/src/serial.rs
@@ -72,10 +72,10 @@ macro_rules! usart {
                     [<$USART Interrupt>]
                 >
                 {
-                    pub unsafe fn new<PINS>(
+                    pub unsafe fn [<$USART:lower>]<PINS>(
                         usart: $USART,
-                        pins: PINS,
                         dma: $DMA,
+                        pins: PINS,
                         tx_int: [<$DMA _ STREAM $TSTREAM Interrupt>],
                         rx_int: [<$DMA _ STREAM $RSTREAM Interrupt>],
                         usart_int: [<$USART Interrupt>],


### PR DESCRIPTION
this should be the final PR to cleanup and finalize the usart interface, and to make it available for a broad range of mcus.