### PR TITLE
Add RTC mod

### DIFF
--- a/embassy-stm32f4/src/lib.rs
+++ b/embassy-stm32f4/src/lib.rs
@@ -313,6 +313,7 @@ pub(crate) mod fmt;
 
 pub mod exti;
 pub mod interrupt;
+pub mod rtc;
 pub mod serial;
 
 pub use cortex_m_rt::interrupt;

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -1,0 +1,261 @@
+use core::cell::Cell;
+use core::ops::Deref;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use embassy::time::Clock;
+
+use crate::fmt::*;
+use crate::interrupt;
+use crate::interrupt::{CriticalSection, Mutex, OwnedInterrupt};
+use crate::pac::tim6;
+
+fn calc_now(period: u32, counter: u32) -> u64 {
+    let shift = ((period & 1) << 23) + 0x400000;
+    let counter_shifted = (counter + shift) & 0xFFFFFF;
+    ((period as u64) << 23) + counter_shifted as u64 - 0x400000
+}
+
+fn compare_n(n: usize) -> u32 {
+    1 << (n + 16)
+}
+
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_calc_now() {
+        assert_eq!(calc_now(0, 0x000000), 0x0_000000);
+        assert_eq!(calc_now(0, 0x000001), 0x0_000001);
+        assert_eq!(calc_now(0, 0x7FFFFF), 0x0_7FFFFF);
+        assert_eq!(calc_now(1, 0x7FFFFF), 0x0_7FFFFF);
+        assert_eq!(calc_now(0, 0x800000), 0x0_800000);
+        assert_eq!(calc_now(1, 0x800000), 0x0_800000);
+        assert_eq!(calc_now(1, 0x800001), 0x0_800001);
+        assert_eq!(calc_now(1, 0xFFFFFF), 0x0_FFFFFF);
+        assert_eq!(calc_now(2, 0xFFFFFF), 0x0_FFFFFF);
+        assert_eq!(calc_now(1, 0x000000), 0x1_000000);
+        assert_eq!(calc_now(2, 0x000000), 0x1_000000);
+    }
+}
+
+struct AlarmState {
+    timestamp: Cell<u64>,
+    callback: Cell<Option<fn()>>,
+}
+
+impl AlarmState {
+    fn new() -> Self {
+        Self {
+            timestamp: Cell::new(u64::MAX),
+            callback: Cell::new(None),
+        }
+    }
+}
+
+const ALARM_COUNT: usize = 3;
+
+pub struct RTC<T: Instance> {
+    rtc: T,
+    irq: T::Interrupt,
+
+    /// Number of 2^23 periods elapsed since boot.
+    ///
+    /// This is incremented by 1
+    /// - on overflow (counter value 0)
+    /// - on "midway" between overflows (at counter value 0x800000)
+    ///
+    /// Therefore: When even, counter is in 0..0x7fffff. When odd, counter is in 0x800000..0xFFFFFF
+    /// This allows for now() to return the correct value even if it races an overflow.
+    ///
+    /// It overflows on 2^32 * 2^23 / 32768 seconds of uptime, which is 34865 years.
+    period: AtomicU32,
+
+    /// Timestamp at which to fire alarm. u64::MAX if no alarm is scheduled.
+    alarms: Mutex<[AlarmState; ALARM_COUNT]>,
+}
+
+unsafe impl<T: Instance> Send for RTC<T> {}
+unsafe impl<T: Instance> Sync for RTC<T> {}
+
+impl<T: Instance> RTC<T> {
+    pub fn new(rtc: T, irq: T::Interrupt) -> Self {
+        Self {
+            rtc,
+            irq,
+            period: AtomicU32::new(0),
+            alarms: Mutex::new([AlarmState::new(), AlarmState::new(), AlarmState::new()]),
+        }
+    }
+
+    pub fn start(&'static self) {
+        // (&mut self.rtc).cr1.write(|w| w.arpe());
+        &(*T::ptr()).cr1.write(|w| (&mut w).arpe());
+
+        self.rtc.cc[3].write(|w| unsafe { w.bits(0x800000) });
+
+        self.rtc.intenset.write(|w| {
+            let w = w.ovrflw().set();
+            let w = w.compare3().set();
+            w
+        });
+
+        self.rtc.tasks_clear.write(|w| unsafe { w.bits(1) });
+        self.rtc.tasks_start.write(|w| unsafe { w.bits(1) });
+
+        // Wait for clear
+        while self.rtc.counter.read().bits() != 0 {}
+
+        self.irq.set_handler(
+            |ptr| unsafe {
+                let this = &*(ptr as *const () as *const Self);
+                this.on_interrupt();
+            },
+            self as *const _ as *mut _,
+        );
+        self.irq.unpend();
+        self.irq.enable();
+    }
+
+    fn on_interrupt(&self) {
+        if self.rtc.events_ovrflw.read().bits() == 1 {
+            self.rtc.events_ovrflw.write(|w| w);
+            self.next_period();
+        }
+
+        if self.rtc.events_compare[3].read().bits() == 1 {
+            self.rtc.events_compare[3].write(|w| w);
+            self.next_period();
+        }
+
+        for n in 0..ALARM_COUNT {
+            if self.rtc.events_compare[n].read().bits() == 1 {
+                self.rtc.events_compare[n].write(|w| w);
+                interrupt::free(|cs| {
+                    self.trigger_alarm(n, cs);
+                })
+            }
+        }
+    }
+
+    fn next_period(&self) {
+        interrupt::free(|cs| {
+            let period = self.period.fetch_add(1, Ordering::Relaxed) + 1;
+            let t = (period as u64) << 23;
+
+            for n in 0..ALARM_COUNT {
+                let alarm = &self.alarms.borrow(cs)[n];
+                let at = alarm.timestamp.get();
+
+                let diff = at - t;
+                if diff < 0xc00000 {
+                    self.rtc.cc[n].write(|w| unsafe { w.bits(at as u32 & 0xFFFFFF) });
+                    self.rtc.intenset.write(|w| unsafe { w.bits(compare_n(n)) });
+                }
+            }
+        })
+    }
+
+    fn trigger_alarm(&self, n: usize, cs: &CriticalSection) {
+        self.rtc.intenclr.write(|w| unsafe { w.bits(compare_n(n)) });
+
+        let alarm = &self.alarms.borrow(cs)[n];
+        alarm.timestamp.set(u64::MAX);
+
+        // Call after clearing alarm, so the callback can set another alarm.
+        alarm.callback.get().map(|f| f());
+    }
+
+    fn set_alarm_callback(&self, n: usize, callback: fn()) {
+        interrupt::free(|cs| {
+            let alarm = &self.alarms.borrow(cs)[n];
+            alarm.callback.set(Some(callback));
+        })
+    }
+
+    fn set_alarm(&self, n: usize, timestamp: u64) {
+        interrupt::free(|cs| {
+            let alarm = &self.alarms.borrow(cs)[n];
+            alarm.timestamp.set(timestamp);
+
+            let t = self.now();
+            if timestamp <= t {
+                self.trigger_alarm(n, cs);
+                return;
+            }
+
+            let diff = timestamp - t;
+            if diff < 0xc00000 {
+                // nrf52 docs say:
+                //    If the COUNTER is N, writing N or N+1 to a CC register may not trigger a COMPARE event.
+                // To workaround this, we never write a timestamp smaller than N+3.
+                // N+2 is not safe because rtc can tick from N to N+1 between calling now() and writing cc.
+                let safe_timestamp = timestamp.max(t + 3);
+                self.rtc.cc[n].write(|w| unsafe { w.bits(safe_timestamp as u32 & 0xFFFFFF) });
+                self.rtc.intenset.write(|w| unsafe { w.bits(compare_n(n)) });
+            } else {
+                self.rtc.intenclr.write(|w| unsafe { w.bits(compare_n(n)) });
+            }
+        })
+    }
+
+    pub fn alarm0(&'static self) -> Alarm<T> {
+        Alarm { n: 0, rtc: self }
+    }
+    pub fn alarm1(&'static self) -> Alarm<T> {
+        Alarm { n: 1, rtc: self }
+    }
+    pub fn alarm2(&'static self) -> Alarm<T> {
+        Alarm { n: 2, rtc: self }
+    }
+}
+
+impl<T: Instance> embassy::time::Clock for RTC<T> {
+    fn now(&self) -> u64 {
+        let counter = self.rtc.counter.read().bits();
+        let period = self.period.load(Ordering::Relaxed);
+        calc_now(period, counter)
+    }
+}
+
+pub struct Alarm<T: Instance> {
+    n: usize,
+    rtc: &'static RTC<T>,
+}
+
+impl<T: Instance> embassy::time::Alarm for Alarm<T> {
+    fn set_callback(&self, callback: fn()) {
+        self.rtc.set_alarm_callback(self.n, callback);
+    }
+
+    fn set(&self, timestamp: u64) {
+        self.rtc.set_alarm(self.n, timestamp);
+    }
+
+    fn clear(&self) {
+        self.rtc.set_alarm(self.n, u64::MAX);
+    }
+}
+
+mod sealed {
+    pub trait Instance {}
+
+    impl Instance for crate::pac::TIM7 {}
+}
+
+/// Implemented by all RTC instances.
+pub trait Instance:
+    sealed::Instance + Deref<Target = tim6::RegisterBlock> + Sized + 'static
+{
+    /// The interrupt associated with this RTC instance.
+    type Interrupt: OwnedInterrupt;
+
+    fn ptr() -> *const tim6::RegisterBlock;
+}
+
+impl Instance for crate::pac::TIM7 {
+    type Interrupt = interrupt::TIM7Interrupt;
+
+    fn ptr() -> *const tim6::RegisterBlock {
+        crate::pac::TIM7::ptr() as *const _
+    }
+}

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -103,7 +103,7 @@ impl<T: Instance> RTC<T> {
         self.irq.enable();
 
         // enable "one-pulse" mode
-        self.rtc.cr1().modify(|_, w| w.opm().set_bit());
+        // self.rtc.cr1().modify(|_, w| w.opm().set_bit());
 
         self.rtc.cr1().modify(|_, w| w.cen().set_bit());
     }
@@ -142,7 +142,7 @@ impl<T: Instance> RTC<T> {
 
         self.reset_timestamp();
         self.recompute();
-        self.rtc.cr1().modify(|_, w| w.cen().set_bit());
+        // self.rtc.cr1().modify(|_, w| w.cen().set_bit());
     }
 
     fn set_alarm_callback(&self, n: usize, callback: fn(*mut ()), ctx: *mut ()) {
@@ -153,14 +153,14 @@ impl<T: Instance> RTC<T> {
     }
 
     fn set_alarm(&self, n: usize, alarm_timestamp: u64) {
-        self.rtc.cr1().modify(|_, w| w.cen().clear_bit());
+        // self.rtc.cr1().modify(|_, w| w.cen().clear_bit());
 
         interrupt::free(|cs| {
             (&self.alarms.borrow(cs)[n]).timestamp.set(alarm_timestamp);
         });
 
         self.recompute();
-        self.rtc.cr1().modify(|_, w| w.cen().set_bit());
+        // self.rtc.cr1().modify(|_, w| w.cen().set_bit());
     }
 
     pub fn alarm0(&'static self) -> Alarm<T> {

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -199,6 +199,10 @@ impl<T: Instance> embassy::time::Alarm for Alarm<T> {
     }
 }
 
+/*
+    TODO: impl. on tim9
+*/
+
 mod sealed {
     pub trait Instance {}
 }

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -8,7 +8,7 @@ use crate::hal::bb;
 use crate::hal::rcc::Clocks;
 use crate::interrupt;
 use crate::interrupt::{CriticalSection, Mutex, OwnedInterrupt};
-use crate::pac::{generic, tim6, RCC};
+use crate::pac::{tim6, RCC};
 
 struct AlarmState {
     timestamp: Cell<u64>,
@@ -221,13 +221,13 @@ pub trait Instance: sealed::Instance + Sized + 'static {
     /// The interrupt associated with this RTC instance.
     type Interrupt: OwnedInterrupt;
 
-    fn cr1(&self) -> generic::Reg<u32, tim6::_CR1>;
-    fn egr(&self) -> generic::Reg<u32, tim6::_EGR>;
-    fn psc(&self) -> generic::Reg<u32, tim6::_PSC>;
-    fn cnt(&self) -> generic::Reg<u32, tim6::_CNT>;
-    fn dier(&self) -> generic::Reg<u32, tim6::_DIER>;
-    fn arr(&self) -> generic::Reg<u32, tim6::_ARR>;
-    fn sr(&self) -> generic::Reg<u32, tim6::_SR>;
+    fn cr1(&self) -> tim6::CR1;
+    fn egr(&self) -> tim6::EGR;
+    fn psc(&self) -> tim6::PSC;
+    fn cnt(&self) -> tim6::CNT;
+    fn dier(&self) -> tim6::DIER;
+    fn arr(&self) -> tim6::ARR;
+    fn sr(&self) -> tim6::SR;
 
     fn enable_clock();
     fn ppre(clocks: Clocks) -> u8;
@@ -237,83 +237,32 @@ pub trait Instance: sealed::Instance + Sized + 'static {
 impl Instance for crate::pac::TIM7 {
     type Interrupt = interrupt::TIM7Interrupt;
 
-    fn arr(&self) -> generic::Reg<u32, tim6::_ARR> {
-        (&(*crate::pac::TIM7::ptr())).arr
+    fn arr(&self) -> tim6::ARR {
+        unsafe { (&(*crate::pac::TIM7::ptr())) }.arr
     }
 
-    fn cr1(&self) -> generic::Reg<u32, tim6::_CR1> {
-        (&(*crate::pac::TIM7::ptr())).cr1
+    fn cr1(&self) -> tim6::CR1 {
+        unsafe { (&(*crate::pac::TIM7::ptr())).cr1 }
     }
 
-    fn egr(&self) -> generic::Reg<u32, tim6::_EGR> {
+    fn egr(&self) -> tim6::EGR {
         (&(*crate::pac::TIM7::ptr())).egr
     }
 
-    fn psc(&self) -> generic::Reg<u32, tim6::_PSC> {
+    fn psc(&self) -> tim6::PSC {
         (&(*crate::pac::TIM7::ptr())).psc
     }
 
-    fn cnt(&self) -> generic::Reg<u32, tim6::_CNT> {
+    fn cnt(&self) -> tim6::CNT {
         (&(*crate::pac::TIM7::ptr())).cnt
     }
 
-    fn dier(&self) -> generic::Reg<u32, tim6::_DIER> {
+    fn dier(&self) -> tim6::DIER {
         (&(*crate::pac::TIM7::ptr())).dier
     }
 
-    fn sr(&self) -> generic::Reg<u32, tim6::_SR> {
+    fn sr(&self) -> tim6::SR {
         (&(*crate::pac::TIM7::ptr())).sr
-    }
-
-    fn ppre(clocks: Clocks) -> u8 {
-        clocks.ppre1()
-    }
-
-    fn pclk(clocks: Clocks) -> u32 {
-        clocks.pclk1().0
-    }
-
-    fn enable_clock() {
-        unsafe {
-            //NOTE(unsafe) this reference will only be used for atomic writes with no side effects
-            let rcc = &(*RCC::ptr());
-            // Enable and reset the timer peripheral, it's the same bit position for both registers
-            bb::set(&rcc.apb1enr, 5);
-            bb::set(&rcc.apb1rstr, 5);
-            bb::clear(&rcc.apb1rstr, 5);
-        }
-    }
-}
-
-impl Instance for crate::pac::TIM2 {
-    type Interrupt = interrupt::TIM2Interrupt;
-
-    fn arr(&self) -> generic::Reg<u32, tim6::_ARR> {
-        (&(*crate::pac::TIM2::ptr())).arr
-    }
-
-    fn cr1(&self) -> generic::Reg<u32, tim6::_CR1> {
-        (&(*crate::pac::TIM2::ptr())).cr1
-    }
-
-    fn egr(&self) -> generic::Reg<u32, tim6::_EGR> {
-        (&(*crate::pac::TIM2::ptr())).egr
-    }
-
-    fn psc(&self) -> generic::Reg<u32, tim6::_PSC> {
-        (&(*crate::pac::TIM2::ptr())).psc
-    }
-
-    fn cnt(&self) -> generic::Reg<u32, tim6::_CNT> {
-        (&(*crate::pac::TIM2::ptr())).cnt
-    }
-
-    fn dier(&self) -> generic::Reg<u32, tim6::_DIER> {
-        (&(*crate::pac::TIM2::ptr())).dier
-    }
-
-    fn sr(&self) -> generic::Reg<u32, tim6::_SR> {
-        (&(*crate::pac::TIM2::ptr())).sr
     }
 
     fn ppre(clocks: Clocks) -> u8 {

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -221,13 +221,13 @@ pub trait Instance: sealed::Instance + Sized + 'static {
     /// The interrupt associated with this RTC instance.
     type Interrupt: OwnedInterrupt;
 
-    fn cr1(&self) -> tim6::CR1;
-    fn egr(&self) -> tim6::EGR;
-    fn psc(&self) -> tim6::PSC;
-    fn cnt(&self) -> tim6::CNT;
-    fn dier(&self) -> tim6::DIER;
-    fn arr(&self) -> tim6::ARR;
-    fn sr(&self) -> tim6::SR;
+    fn cr1(&self) -> &tim6::CR1;
+    fn egr(&self) -> &tim6::EGR;
+    fn psc(&self) -> &tim6::PSC;
+    fn cnt(&self) -> &tim6::CNT;
+    fn dier(&self) -> &tim6::DIER;
+    fn arr(&self) -> &tim6::ARR;
+    fn sr(&self) -> &tim6::SR;
 
     fn enable_clock();
     fn ppre(clocks: Clocks) -> u8;
@@ -237,32 +237,32 @@ pub trait Instance: sealed::Instance + Sized + 'static {
 impl Instance for crate::pac::TIM7 {
     type Interrupt = interrupt::TIM7Interrupt;
 
-    fn arr(&self) -> tim6::ARR {
-        unsafe { (&(*crate::pac::TIM7::ptr())) }.arr
+    fn arr(&self) -> &tim6::ARR {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).arr }
     }
 
-    fn cr1(&self) -> tim6::CR1 {
-        unsafe { (&(*crate::pac::TIM7::ptr())).cr1 }
+    fn cr1(&self) -> &tim6::CR1 {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).cr1 }
     }
 
-    fn egr(&self) -> tim6::EGR {
-        (&(*crate::pac::TIM7::ptr())).egr
+    fn egr(&self) -> &tim6::EGR {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).egr }
     }
 
-    fn psc(&self) -> tim6::PSC {
-        (&(*crate::pac::TIM7::ptr())).psc
+    fn psc(&self) -> &tim6::PSC {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).psc }
     }
 
-    fn cnt(&self) -> tim6::CNT {
-        (&(*crate::pac::TIM7::ptr())).cnt
+    fn cnt(&self) -> &tim6::CNT {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).cnt }
     }
 
-    fn dier(&self) -> tim6::DIER {
-        (&(*crate::pac::TIM7::ptr())).dier
+    fn dier(&self) -> &tim6::DIER {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).dier }
     }
 
-    fn sr(&self) -> tim6::SR {
-        (&(*crate::pac::TIM7::ptr())).sr
+    fn sr(&self) -> &tim6::SR {
+        unsafe { &(&(*crate::pac::TIM7::ptr())).sr }
     }
 
     fn ppre(clocks: Clocks) -> u8 {

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -177,6 +177,11 @@ impl<T: Instance> RTC<T> {
                 .deref()
                 .arr
                 .write(|w| unsafe { w.bits(diff as u32) });
+
+            // Trigger update event to load the registers
+            self.rtc.deref().cr1.modify(|_, w| w.urs().set_bit());
+            self.rtc.deref().egr.write(|w| w.ug().set_bit());
+            self.rtc.deref().cr1.modify(|_, w| w.urs().clear_bit());
         }
 
         self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -12,7 +12,7 @@ use crate::pac::{tim6, RCC};
 
 struct AlarmState {
     timestamp: Cell<u64>,
-    callback: Cell<Option<fn()>>,
+    callback: Cell<Option<(fn(*mut ()), *mut ())>>,
 }
 
 impl AlarmState {
@@ -145,13 +145,13 @@ impl<T: Instance> RTC<T> {
         alarm.timestamp.set(u64::MAX);
 
         // Call after clearing alarm, so the callback can set another alarm.
-        alarm.callback.get().map(|f| f());
+        alarm.callback.get().map(|(f, ctx)| f(ctx));
     }
 
-    fn set_alarm_callback(&self, n: usize, callback: fn()) {
+    fn set_alarm_callback(&self, n: usize, callback: fn(*mut ()), ctx: *mut ()) {
         interrupt::free(|cs| {
             let alarm = &self.alarms.borrow(cs)[n];
-            alarm.callback.set(Some(callback));
+            alarm.callback.set(Some((callback, ctx)));
         })
     }
 
@@ -210,8 +210,8 @@ pub struct Alarm<T: Instance> {
 }
 
 impl<T: Instance> embassy::time::Alarm for Alarm<T> {
-    fn set_callback(&self, callback: fn()) {
-        self.rtc.set_alarm_callback(self.n, callback);
+    fn set_callback(&self, callback: fn(*mut()), ctx: *mut ()) {
+        self.rtc.set_alarm_callback(self.n, callback, ctx);
     }
 
     fn set(&self, timestamp: u64) {

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -171,7 +171,7 @@ impl<T: Instance> RTC<T> {
 
 impl<T: Instance> embassy::time::Clock for RTC<T> {
     fn now(&self) -> u64 {
-        self.timestamp + unsafe { (*T::ptr()).cnt.read().bits() } as u64
+        self.timestamp + self.prtc().cnt.read().bits() as u64
     }
 }
 

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -54,7 +54,7 @@ impl<T: Instance> RTC<T> {
     }
 
     pub fn start(&mut self) {
-        // pause
+        // stop counter
         self.rtc.deref().cr1.modify(|_, w| w.cen().clear_bit());
         // reset counter
         self.rtc.deref().cnt.reset();
@@ -90,6 +90,9 @@ impl<T: Instance> RTC<T> {
         self.irq.unpend();
         self.irq.enable();
 
+        // start counter
+        self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());
+
         self.reset();
     }
 
@@ -97,35 +100,59 @@ impl<T: Instance> RTC<T> {
         reset the state and recompute values
     */
     fn reset(&mut self) {
-        self.rtc.deref().cr1.modify(|_, w| w.cen().clear_bit());
         self.timestamp += self.rtc.deref().arr.read().bits() as u64;
         let mut arr = u32::MAX;
 
         interrupt::free(|cs| {
             for n in 0..2 {
                 let alarm = &self.alarms.borrow(cs)[n];
-                let diff: i64 = alarm.timestamp.get() as i64 - self.timestamp as i64;
+                let alarm_timestamp = alarm.timestamp.get();
+                let self_timestamp = self.timestamp;
+                
+                let diff: u64;
+                if alarm_timestamp > self_timestamp {
+                    diff = (alarm_timestamp - self_timestamp);
+                } else {
+                    diff = 0;
+                }
+
+                let is_greater = alarm_timestamp > self_timestamp;
 
                 if diff < 5 {
                     self.trigger_alarm(n, cs);
-                } else if diff < arr as i64 {
+                } else if diff < arr as u64 {
                     arr = diff as u32;
                 }
             }
         });
+
+
+        // stop counter
+        self.rtc.deref().cr1.modify(|_, w| w.cen().clear_bit());
         // set alarm value
         self.rtc.deref().arr.write(|w| unsafe { w.bits(arr) });
         // reset counter
         self.rtc.deref().cnt.reset();
         // start counter
         self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());
+
+        let cnt = self.rtc.deref().cnt.read().bits();
+
+        let is_geq = cnt > 10;
+        if is_geq {
+            let j = 1;
+        } else {
+            let j = 1;
+        }
     }
 
     unsafe fn on_interrupt(&mut self) {
-        // Clear interrupt flag
-        self.rtc.deref().sr.write(|w| w.uif().clear_bit());
+        self.irq.unpend();
 
         self.reset();
+
+        // Clear interrupt flag
+        self.rtc.deref().sr.write(|w| w.uif().clear_bit());
     }
 
     fn trigger_alarm(&self, n: usize, cs: &CriticalSection) {
@@ -146,20 +173,25 @@ impl<T: Instance> RTC<T> {
     }
 
     fn set_alarm(&self, n: usize, timestamp: u64) {
-        interrupt::free(|cs| {
-            let alarm = &self.alarms.borrow(cs)[n];
-            alarm.timestamp.set(timestamp);
-        });
+        let alarm_timestamp = timestamp;
+        let self_timestamp = self.now();
+        
+        let diff: u64;
+        if alarm_timestamp > self_timestamp {
+            diff = (alarm_timestamp - self_timestamp);
+        } else {
+            diff = 0;
+        }
 
-        let arr = self.rtc.deref().arr.read().bits();
-        let diff: i64 = timestamp as i64 - self.now() as i64;
+        let is_greater = alarm_timestamp > self_timestamp;
+        let arr = self.rtc.deref().arr.read().bits() as u64;
+
         if diff < 5 {
             interrupt::free(|cs| {
                 self.trigger_alarm(n, cs);
             });
-        } else if diff < arr as i64 {
-            // set alarm value
-            self.rtc.deref().arr.write(|w| unsafe { w.bits(arr) });
+        } else if diff < arr as u64 {
+            self.rtc.deref().arr.write(|w| unsafe { w.bits(diff as u32) });
         }
     }
 

--- a/embassy-stm32f4/src/rtc.rs
+++ b/embassy-stm32f4/src/rtc.rs
@@ -86,8 +86,7 @@ impl<T: Instance> RTC<T> {
         let psc = ((ticks - 1) / (1 << 16)) as u16;
         self.rtc.deref().psc.write(|w| w.psc().bits(psc));
 
-        let arr = (ticks / (psc + 1) as u32) as u32;
-        self.set_arr(arr);
+        self.set_arr(u16::MAX as u32);
 
         // enable interrupt
         self.rtc.deref().dier.write(|w| w.uie().set_bit());
@@ -103,7 +102,7 @@ impl<T: Instance> RTC<T> {
         self.irq.enable();
 
         // enable "one-pulse" mode
-        self.rtc.deref().cr1.modify(|_, w| w.opm().set_bit());
+        // self.rtc.deref().cr1.modify(|_, w| w.opm().set_bit());
 
         self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());
     }
@@ -142,7 +141,7 @@ impl<T: Instance> RTC<T> {
 
         self.reset_timestamp();
         self.recompute();
-        self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());
+        // self.rtc.deref().cr1.modify(|_, w| w.cen().set_bit());
     }
 
     fn trigger_alarm(&self, n: usize, cs: &CriticalSection) {


### PR DESCRIPTION
Fixes #38.

Details of this scheme:

Each STM32 timer is a timer. It is set for a variable length of time and when the time is elapsed, an interrupt is generated. It can also be read to determine how much time has elapsed.

To avoid consuming more than  one timer, it is possible to generate a clock and n alarms from a timer. The value of the clock is simply the total time that has elapsed, and each alarm can be generated by setting the timer to the soonest alarm.

This differs from nrf because a 64 bit add is required every time the timer expires, because the period is variable, rather than the nrf approach, which only requires a 64 bit add each time the clock is read. 