### PR TITLE
update defmt and defmt-rtt to 0.2.0

### DIFF
--- a/embassy-nrf-examples/.cargo/config
+++ b/embassy-nrf-examples/.cargo/config
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip nRF52840_xxAA --defmt"
+runner = "probe-run --chip nRF52840_xxAA"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/embassy-nrf-examples/Cargo.toml
+++ b/embassy-nrf-examples/Cargo.toml
@@ -20,8 +20,8 @@ defmt-error = []
 embassy = { version = "0.1.0", path = "../embassy", features = ["defmt", "defmt-trace"] }
 embassy-nrf = { version = "0.1.0", path = "../embassy-nrf", features = ["defmt", "defmt-trace", "52840"] }
 
-defmt = "0.1.3"
-defmt-rtt = "0.1.0"
+defmt = "0.2.0"
+defmt-rtt = "0.2.0"
 
 cortex-m = "0.7.1"
 cortex-m-rt = "0.6.13"

--- a/embassy-nrf-examples/src/bin/buffered_uart.rs
+++ b/embassy-nrf-examples/src/bin/buffered_uart.rs
@@ -64,7 +64,7 @@ async fn run() {
         info!("reading...");
         let mut buf = [0u8; 8];
         unwrap!(u.read_exact(&mut buf).await);
-        info!("read done, got {:[u8]}", buf);
+        info!("read done, got {}", buf);
 
         // Reverse buf
         for i in 0..4 {

--- a/embassy-nrf-examples/src/bin/multiprio.rs
+++ b/embassy-nrf-examples/src/bin/multiprio.rs
@@ -90,7 +90,7 @@ async fn run_med() {
 
         let end = Instant::now();
         let ms = end.duration_since(start).as_ticks() / 33;
-        info!("    [med] done in {:u64} ms", ms);
+        info!("    [med] done in {} ms", ms);
 
         Timer::after(Duration::from_ticks(23421)).await;
     }
@@ -107,7 +107,7 @@ async fn run_low() {
 
         let end = Instant::now();
         let ms = end.duration_since(start).as_ticks() / 33;
-        info!("[low] done in {:u64} ms", ms);
+        info!("[low] done in {} ms", ms);
 
         Timer::after(Duration::from_ticks(32983)).await;
     }

--- a/embassy-nrf-examples/src/bin/qspi.rs
+++ b/embassy-nrf-examples/src/bin/qspi.rs
@@ -73,7 +73,7 @@ async fn run() {
 
     let mut id = [1; 3];
     q.custom_instruction(0x9F, &[], &mut id).await.unwrap();
-    info!("id: {:[u8]}", id);
+    info!("id: {}", id);
 
     // Read status register
     let mut status = [0; 1];

--- a/embassy-nrf-examples/src/bin/rtc_raw.rs
+++ b/embassy-nrf-examples/src/bin/rtc_raw.rs
@@ -48,15 +48,12 @@ fn main() -> ! {
     loop {
         let val2 = rtc.now();
         if val2 < val {
-            info!(
-                "timer ran backwards! {:u32} -> {:u32}",
-                val as u32, val2 as u32
-            );
+            info!("timer ran backwards! {} -> {}", val as u32, val2 as u32);
         }
         val = val2;
 
         if val > printval + 32768 {
-            info!("tick {:u32}", val as u32);
+            info!("tick {}", val as u32);
             printval = val;
         }
     }

--- a/embassy-nrf-examples/src/bin/uart.rs
+++ b/embassy-nrf-examples/src/bin/uart.rs
@@ -76,7 +76,7 @@ async fn run(uart: pac::UARTE0, port: pac::P0) {
         let received = &mut buf[..received_len];
 
         if !received.is_empty() {
-            info!("read done, got {:[u8]}", received);
+            info!("read done, got {}", received);
 
             // Echo back received data
             unwrap!(uart.send(received).await);

--- a/embassy-nrf-examples/src/example_common.rs
+++ b/embassy-nrf-examples/src/example_common.rs
@@ -8,11 +8,11 @@ pub use defmt::*;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[defmt::timestamp]
-fn timestamp() -> u64 {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // NOTE(no-CAS) `timestamps` runs with interrupts disabled
-    let n = COUNT.load(Ordering::Relaxed);
-    COUNT.store(n + 1, Ordering::Relaxed);
-    n as u64
+defmt::timestamp! {"{=u64}", {
+        static COUNT: AtomicUsize = AtomicUsize::new(0);
+        // NOTE(no-CAS) `timestamps` runs with interrupts disabled
+        let n = COUNT.load(Ordering::Relaxed);
+        COUNT.store(n + 1, Ordering::Relaxed);
+        n as u64
+    }
 }

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -21,7 +21,7 @@ defmt-error = [ ]
 [dependencies]
 embassy = { version = "0.1.0", path = "../embassy" }
 
-defmt = { version = "0.1.3", optional = true }
+defmt = { version = "0.2.0", optional = true }
 log = { version = "0.4.11", optional = true }
 cortex-m-rt = "0.6.13"
 cortex-m = "0.7.1"

--- a/embassy-stm32f4-examples/.cargo/config
+++ b/embassy-stm32f4-examples/.cargo/config
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip STM32F401CCUx --defmt"
+runner = "probe-run --chip STM32F401CCUx"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/embassy-stm32f4-examples/Cargo.toml
+++ b/embassy-stm32f4-examples/Cargo.toml
@@ -20,8 +20,8 @@ defmt-error = []
 embassy = { version = "0.1.0", path = "../embassy", features = ["defmt", "defmt-trace"] }
 embassy-stm32f4 = { version = "*", path = "../embassy-stm32f4", features = ["stm32f401"] }
 
-defmt = "0.1.3"
-defmt-rtt = "0.1.0"
+defmt = "0.2.0"
+defmt-rtt = "0.2.0"
 
 cortex-m = "0.7.1"
 cortex-m-rt = "0.6.13"

--- a/embassy-stm32f4-examples/src/example_common.rs
+++ b/embassy-stm32f4-examples/src/example_common.rs
@@ -7,11 +7,11 @@ pub use defmt::*;
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-#[defmt::timestamp]
-fn timestamp() -> u64 {
-    static COUNT: AtomicUsize = AtomicUsize::new(0);
-    // NOTE(no-CAS) `timestamps` runs with interrupts disabled
-    let n = COUNT.load(Ordering::Relaxed);
-    COUNT.store(n + 1, Ordering::Relaxed);
-    n as u64
+defmt::timestamp! {"{=u64}", {
+        static COUNT: AtomicUsize = AtomicUsize::new(0);
+        // NOTE(no-CAS) `timestamps` runs with interrupts disabled
+        let n = COUNT.load(Ordering::Relaxed);
+        COUNT.store(n + 1, Ordering::Relaxed);
+        n as u64
+    }
 }

--- a/embassy-stm32f4/Cargo.toml
+++ b/embassy-stm32f4/Cargo.toml
@@ -32,7 +32,7 @@ stm32f479 = ["stm32f4xx-hal/stm32f469"]
 [dependencies]
 embassy = { version = "0.1.0", path = "../embassy" }
 
-defmt = { version = "0.1.3", optional = true }
+defmt = { version = "0.2.0", optional = true }
 log = { version = "0.4.11", optional = true }
 cortex-m-rt = "0.6.13"
 cortex-m = "0.7.1"

--- a/embassy/Cargo.toml
+++ b/embassy/Cargo.toml
@@ -13,7 +13,7 @@ defmt-warn = []
 defmt-error = []
 
 [dependencies]
-defmt = { version = "0.1.3", optional = true }
+defmt = { version = "0.2.0", optional = true }
 log = { version = "0.4.11", optional = true }
 
 cortex-m = "0.7.1"


### PR DESCRIPTION
mostly to go along with the same update to nrf-softdevice (because {:x} is awesome)