### PR TITLE
stm32f4: exti: clear interrupt pending bit

### DIFF
--- a/embassy-stm32f4/src/exti.rs
+++ b/embassy-stm32f4/src/exti.rs
@@ -60,9 +60,9 @@ impl<T: HalExtiPin + 'static, I: OwnedInterrupt + 'static> WaitForRisingEdge for
     fn wait_for_rising_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a> {
         let s = unsafe { self.get_unchecked_mut() };
 
+        s.pin.clear_interrupt_pending_bit();
         async move {
             let fut = InterruptFuture::new(&mut s.interrupt);
-            s.pin.clear_interrupt_pending_bit();
             let mut exti: EXTI = unsafe { mem::transmute(()) };
 
             s.pin.trigger_on_edge(&mut exti, Edge::RISING);
@@ -80,9 +80,9 @@ impl<T: HalExtiPin + 'static, I: OwnedInterrupt + 'static> WaitForFallingEdge fo
     fn wait_for_falling_edge<'a>(self: Pin<&'a mut Self>) -> Self::Future<'a> {
         let s = unsafe { self.get_unchecked_mut() };
 
+        s.pin.clear_interrupt_pending_bit();
         async move {
             let fut = InterruptFuture::new(&mut s.interrupt);
-            s.pin.clear_interrupt_pending_bit();
             let mut exti: EXTI = unsafe { mem::transmute(()) };
 
             s.pin.trigger_on_edge(&mut exti, Edge::FALLING);


### PR DESCRIPTION
Bit should be cleared when created. This caused problems in my application, but I had to have the RTC fixed to see it.