### PR TITLE
add delay trait

### DIFF
--- a/embassy-traits/src/delay.rs
+++ b/embassy-traits/src/delay.rs
@@ -1,0 +1,9 @@
+use core::future::Future;
+use core::pin::Pin;
+
+pub trait Delay {
+    type DelayFuture<'a>: Future<Output = ()> + 'a;
+
+    fn delay_ms<'a>(self: Pin<&'a mut Self>, millis: u64) -> Self::DelayFuture<'a>;
+    fn delay_us<'a>(self: Pin<&'a mut Self>, micros: u64) -> Self::DelayFuture<'a>;
+}

--- a/embassy-traits/src/lib.rs
+++ b/embassy-traits/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(const_option)]
 #![allow(incomplete_features)]
 
+pub mod delay;
 pub mod flash;
 pub mod gpio;
 pub mod uart;

--- a/embassy/src/executor/timer.rs
+++ b/embassy/src/executor/timer.rs
@@ -1,10 +1,34 @@
 use core::future::Future;
+use core::marker::PhantomData;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures::Stream;
 
 use super::raw;
 use crate::time::{Duration, Instant};
+
+pub struct Delay {
+    _data: PhantomData<bool>,
+}
+
+impl Delay {
+    pub fn new() -> Self {
+        Delay {
+            _data: PhantomData {},
+        }
+    }
+}
+
+impl crate::traits::delay::Delay for Delay {
+    type DelayFuture<'a> = impl Future<Output = ()> + 'a;
+
+    fn delay_ms<'a>(self: Pin<&'a mut Self>, millis: u64) -> Self::DelayFuture<'a> {
+        Timer::after(Duration::from_millis(millis))
+    }
+    fn delay_us<'a>(self: Pin<&'a mut Self>, micros: u64) -> Self::DelayFuture<'a> {
+        Timer::after(Duration::from_micros(micros))
+    }
+}
 
 pub struct Timer {
     expires_at: Instant,

--- a/embassy/src/lib.rs
+++ b/embassy/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_fn_fn_ptr_basics)]
 #![feature(const_option)]
 #![allow(incomplete_features)]
+#![feature(type_alias_impl_trait)]
 
 // This mod MUST go first, so that the others see its macros.
 pub(crate) mod fmt;

--- a/embassy/src/time/duration.rs
+++ b/embassy/src/time/duration.rs
@@ -45,9 +45,9 @@ impl Duration {
     /*
         NOTE: us delays may not be as accurate
     */
-    pub const fn from_micros(millis: u64) -> Duration {
+    pub const fn from_micros(micros: u64) -> Duration {
         Duration {
-            ticks: millis * TICKS_PER_SECOND / 1_000_000,
+            ticks: micros * TICKS_PER_SECOND / 1_000_000,
         }
     }
 


### PR DESCRIPTION
There needs to be a generic timer trait that is not tied to embassy for other libraries to depend on.