### PR TITLE
add qei trait and impl

### DIFF
--- a/embassy-stm32f4/src/lib.rs
+++ b/embassy-stm32f4/src/lib.rs
@@ -313,5 +313,6 @@ pub(crate) mod fmt;
 
 pub mod exti;
 pub mod interrupt;
+pub mod qei;
 pub mod rtc;
 pub mod serial;

--- a/embassy-stm32f4/src/qei.rs
+++ b/embassy-stm32f4/src/qei.rs
@@ -1,0 +1,95 @@
+use crate::interrupt;
+use core::future::Future;
+use core::pin::Pin;
+use embassy::interrupt::Interrupt;
+use embassy::traits::qei::WaitForRotate;
+use embedded_hal::Direction;
+use embedded_hal::Qei as THQei;
+use stm32f4xx_hal::pac::TIM2;
+use stm32f4xx_hal::qei::{Pins, Qei as HalQei};
+
+pub struct Qei<T: Instance, PINS> {
+    qei: HalQei<T, PINS>,
+    int: T::Interrupt,
+}
+
+impl<PINS: Pins<TIM2>> Qei<TIM2, PINS> {
+    pub fn tim2(tim: TIM2, pins: PINS, interrupt: interrupt::TIM2) -> Self {
+        let qei = HalQei::tim2(tim, pins);
+
+        let tim = unsafe {
+            &mut *(stm32f4xx_hal::stm32::TIM2::ptr()
+                as *mut stm32f4xx_hal::stm32::tim2::RegisterBlock)
+        };
+        /*
+            enable qei interrupt
+        */
+        tim.dier.write(|w| w.uie().set_bit());
+
+        Qei {
+            qei: qei,
+            int: interrupt,
+        }
+    }
+}
+
+impl<PINS: Pins<TIM2> + 'static> WaitForRotate for Qei<TIM2, PINS> {
+    type RotateFuture<'a> = impl Future<Output = Direction> + 'a;
+
+    fn wait_for_rotate<'a>(
+        self: Pin<&'a mut Self>,
+        count_down: u16,
+        count_up: u16,
+    ) -> Self::RotateFuture<'a> {
+        let s = unsafe { self.get_unchecked_mut() };
+
+        let tim = unsafe {
+            &mut *(stm32f4xx_hal::stm32::TIM2::ptr()
+                as *mut stm32f4xx_hal::stm32::tim2::RegisterBlock)
+        };
+
+        /*
+            the interrupt will be reached at zero or the max count
+            write the total range to the qei.
+        */
+        tim.arr
+            .write(|w| unsafe { w.bits((count_down + count_up) as u32) });
+
+        /*
+            set timer to the correct value in the range
+        */
+        tim.cnt.write(|w| unsafe { w.bits(count_down as u32) });
+
+        /*
+            clear interrupt flag
+        */
+        tim.sr.write(|w| w.uif().clear_bit());
+
+        async move {
+            embassy::util::InterruptFuture::new(&mut s.int).await;
+
+            if tim.cnt.read().bits() == 0 {
+                Direction::Downcounting
+            } else if tim.cnt.read() == count_down + count_up {
+                Direction::Upcounting
+            } else {
+                panic!("unexpected value")
+            }
+        }
+    }
+}
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+pub trait Instance: sealed::Sealed {
+    type Interrupt: interrupt::Interrupt;
+}
+
+#[cfg(feature = "stm32f405")]
+impl sealed::Sealed for TIM2 {}
+#[cfg(feature = "stm32f405")]
+impl Instance for TIM2 {
+    type Interrupt = interrupt::TIM2;
+}

--- a/embassy-traits/Cargo.toml
+++ b/embassy-traits/Cargo.toml
@@ -9,3 +9,4 @@ std = []
 
 [dependencies]
 defmt = { version = "0.2.0", optional = true }
+embedded-hal = { version = "0.2.3", features = ["unproven"] }

--- a/embassy-traits/src/lib.rs
+++ b/embassy-traits/src/lib.rs
@@ -9,5 +9,6 @@
 pub mod delay;
 pub mod flash;
 pub mod gpio;
+pub mod qei;
 pub mod i2c;
 pub mod uart;

--- a/embassy-traits/src/qei.rs
+++ b/embassy-traits/src/qei.rs
@@ -1,0 +1,14 @@
+use core::future::Future;
+use core::pin::Pin;
+use embedded_hal::Direction;
+
+// Wait for a specified number of rotations either up or down
+pub trait WaitForRotate {
+    type RotateFuture<'a>: Future<Output = Direction> + 'a;
+
+    fn wait_for_rotate<'a>(
+        self: Pin<&'a mut Self>,
+        count_down: u16,
+        count_up: u16,
+    ) -> Self::RotateFuture<'a>;
+}

--- a/embassy-traits/src/qei.rs
+++ b/embassy-traits/src/qei.rs
@@ -6,6 +6,14 @@ use embedded_hal::Direction;
 pub trait WaitForRotate {
     type RotateFuture<'a>: Future<Output = Direction> + 'a;
 
+    /// Wait for a specified number of rotations, in ticks, either up or down.
+    ///
+    /// Return Direction::Upcounting if the high bound is reached.
+    /// Return Direction::Downcounting if the low bound is reached.
+    ///
+    /// Number of ticks is encoder dependent. As an example, if we connect
+    /// the Bourns PEC11H-4120F-S0020, we have 20 ticks per full rotation.
+    /// Other encoders may vary.
     fn wait_for_rotate<'a>(
         self: Pin<&'a mut Self>,
         count_down: u16,


### PR DESCRIPTION
This one may be a little too specific, but in my application I use a knob as a control, and wait for it to move up or down to adjust a menu. The 'async' qei trait allows the user to wait until the encoder has moved up or down a certain number of rotations.