### PR TITLE
Update `nrf-hal` to v0.12.1

### DIFF
--- a/embassy-nrf-examples/Cargo.toml
+++ b/embassy-nrf-examples/Cargo.toml
@@ -28,5 +28,5 @@ cortex-m = { version = "0.7.1", features = ["inline-asm"] }
 cortex-m-rt = "0.6.13"
 embedded-hal    = { version = "0.2.4" }
 panic-probe = "0.1.0"
-nrf52840-hal    = { version = "0.12.0" }
+nrf52840-hal    = { version = "0.12.1" }
 futures = { version = "0.3.8", default-features = false, features = ["async-await"] }

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -35,8 +35,8 @@ nrf52832-pac  = { version = "0.9.0", optional = true }
 nrf52833-pac  = { version = "0.9.0", optional = true }
 nrf52840-pac  = { version = "0.9.0", optional = true }
 
-nrf52810-hal  = { version = "0.12.0", optional = true }
-#nrf52811-hal  = { version = "0.12.0", optional = true }  # doesn't exist yet
-nrf52832-hal  = { version = "0.12.0", optional = true }
-nrf52833-hal  = { version = "0.12.0", optional = true }
-nrf52840-hal  = { version = "0.12.0", optional = true }
+nrf52810-hal  = { version = "0.12.1", optional = true }
+#nrf52811-hal  = { version = "0.12.1", optional = true }  # doesn't exist yet
+nrf52832-hal  = { version = "0.12.1", optional = true }
+nrf52833-hal  = { version = "0.12.1", optional = true }
+nrf52840-hal  = { version = "0.12.1", optional = true }

--- a/embassy-nrf/src/qspi.rs
+++ b/embassy-nrf/src/qspi.rs
@@ -3,7 +3,7 @@ use core::pin::Pin;
 use core::task::Poll;
 
 use crate::fmt::{assert, assert_eq, *};
-use crate::hal::gpio::{Output, Pin as GpioPin, Port as GpioPort, PushPull};
+use crate::hal::gpio::{Output, Pin as GpioPin, PushPull};
 use crate::interrupt::{self};
 use crate::pac::QSPI;
 
@@ -59,43 +59,31 @@ pub struct Qspi {
     inner: PeripheralMutex<State>,
 }
 
-fn port_bit(port: GpioPort) -> bool {
-    match port {
-        GpioPort::Port0 => false,
-        GpioPort::Port1 => true,
-    }
-}
-
 impl Qspi {
     pub fn new(qspi: QSPI, irq: interrupt::QSPI, config: Config) -> Self {
         qspi.psel.sck.write(|w| {
             let pin = &config.pins.sck;
-            let w = unsafe { w.pin().bits(pin.pin()) };
-            let w = w.port().bit(port_bit(pin.port()));
+            unsafe { w.bits(pin.psel_bits()) };
             w.connect().connected()
         });
         qspi.psel.csn.write(|w| {
             let pin = &config.pins.csn;
-            let w = unsafe { w.pin().bits(pin.pin()) };
-            let w = w.port().bit(port_bit(pin.port()));
+            unsafe { w.bits(pin.psel_bits()) };
             w.connect().connected()
         });
         qspi.psel.io0.write(|w| {
             let pin = &config.pins.io0;
-            let w = unsafe { w.pin().bits(pin.pin()) };
-            let w = w.port().bit(port_bit(pin.port()));
+            unsafe { w.bits(pin.psel_bits()) };
             w.connect().connected()
         });
         qspi.psel.io1.write(|w| {
             let pin = &config.pins.io1;
-            let w = unsafe { w.pin().bits(pin.pin()) };
-            let w = w.port().bit(port_bit(pin.port()));
+            unsafe { w.bits(pin.psel_bits()) };
             w.connect().connected()
         });
         qspi.psel.io2.write(|w| {
             if let Some(ref pin) = config.pins.io2 {
-                let w = unsafe { w.pin().bits(pin.pin()) };
-                let w = w.port().bit(port_bit(pin.port()));
+                unsafe { w.bits(pin.psel_bits()) };
                 w.connect().connected()
             } else {
                 w.connect().disconnected()
@@ -103,8 +91,7 @@ impl Qspi {
         });
         qspi.psel.io3.write(|w| {
             if let Some(ref pin) = config.pins.io3 {
-                let w = unsafe { w.pin().bits(pin.pin()) };
-                let w = w.port().bit(port_bit(pin.port()));
+                unsafe { w.bits(pin.psel_bits()) };
                 w.connect().connected()
             } else {
                 w.connect().disconnected()


### PR DESCRIPTION
Use the `psel_bits()` method to reduce #[cfg] clutter